### PR TITLE
Rename project from jc to jcz to avoid naming conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Create source tarball
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          git archive --format=tar.gz --prefix="jc-${VERSION}/" HEAD -o "jc-${VERSION}.tar.gz"
+          git archive --format=tar.gz --prefix="jcz-${VERSION}/" HEAD -o "jcz-${VERSION}.tar.gz"
 
       - name: Install cargo-deb
         run: cargo install cargo-deb
@@ -116,11 +116,11 @@ jobs:
           cat >> Cargo.toml << 'DEBEOF'
 
           [package.metadata.deb]
-          maintainer = "JC Contributors <noreply@github.com>"
-          copyright = "2025, JC Contributors <noreply@github.com>"
+          maintainer = "JCZ Contributors <noreply@github.com>"
+          copyright = "2025, JCZ Contributors <noreply@github.com>"
           license-file = ["LICENSE", "0"]
           extended-description = """\
-          Just Compress (jc) is a unified compression utility that simplifies \
+          Just Compress Zip (jcz) is a unified compression utility that simplifies \
           working with various compression formats including gzip, bzip2, xz, \
           and tar archives. It provides a consistent interface for compression \
           and decompression operations."""
@@ -128,7 +128,7 @@ jobs:
           section = "utils"
           priority = "optional"
           assets = [
-              ["target/release/jc", "usr/bin/", "755"],
+              ["target/release/jcz", "usr/bin/", "755"],
           ]
           DEBEOF
 
@@ -146,9 +146,9 @@ jobs:
 
           if [ -n "$DEB_FILE" ]; then
             VERSION="${{ steps.version.outputs.version }}"
-            cp "$DEB_FILE" "jc_${VERSION}_amd64.deb"
-            echo "Debian package created: jc_${VERSION}_amd64.deb"
-            ls -lh "jc_${VERSION}_amd64.deb"
+            cp "$DEB_FILE" "jcz_${VERSION}_amd64.deb"
+            echo "Debian package created: jcz_${VERSION}_amd64.deb"
+            ls -lh "jcz_${VERSION}_amd64.deb"
           else
             echo "Error: Debian package not found"
             exit 1
@@ -176,8 +176,8 @@ jobs:
           name: Release-${{ steps.version.outputs.version }}
           body_path: changelog.md
           files: |
-            jc-${{ steps.version.outputs.version }}.tar.gz
-            jc_${{ steps.version.outputs.version }}_amd64.deb
+            jcz-${{ steps.version.outputs.version }}.tar.gz
+            jcz_${{ steps.version.outputs.version }}_amd64.deb
           draft: false
           prerelease: false
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "jc"
+name = "jcz"
 version = "0.1.3"
 edition = "2021"
-authors = ["JC Contributors"]
-description = "Just Compress - A unified compression utility"
+authors = ["JCZ Contributors"]
+description = "Just Compress Zip - A unified compression utility"
 license = "MIT"
 repository = "https://github.com/saimizi/jc"
 
@@ -29,7 +29,7 @@ assert_cmd = "2.0"
 predicates = "3.0"
 
 [[bin]]
-name = "jc"
+name = "jcz"
 path = "src/main.rs"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JC - Just Compress (Rust Implementation)
+# JCZ - Just Compress Zip (Rust Implementation)
 
 A unified command-line compression utility written in Rust, providing a consistent interface for multiple compression formats.
 
@@ -18,7 +18,7 @@ A unified command-line compression utility written in Rust, providing a consiste
 
 ```bash
 cargo build --release
-sudo cp target/release/jc /usr/local/bin/
+sudo cp target/release/jcz /usr/local/bin/
 ```
 
 ## Usage
@@ -27,53 +27,53 @@ sudo cp target/release/jc /usr/local/bin/
 
 ```bash
 # Compress with GZIP
-jc -c gzip file.txt
+jcz -c gzip file.txt
 
 # Compress with BZIP2 at level 9
-jc -c bzip2 -l 9 file.txt
+jcz -c bzip2 -l 9 file.txt
 
 # Create TAR archive
-jc -c tar directory/
+jcz -c tar directory/
 ```
 
 ### Compound Formats
 
 ```bash
 # Create .tar.gz
-jc -c tgz directory/
+jcz -c tgz directory/
 
 # Create .tar.bz2
-jc -c tbz2 file1.txt file2.txt
+jcz -c tbz2 file1.txt file2.txt
 
 # Create .tar.xz
-jc -c txz myfiles/
+jcz -c txz myfiles/
 ```
 
 ### Decompression
 
 ```bash
 # Decompress any supported format
-jc -d archive.tar.gz
+jcz -d archive.tar.gz
 
 # Decompress multiple files
-jc -d file1.gz file2.bz2 file3.xz
+jcz -d file1.gz file2.bz2 file3.xz
 ```
 
 ### Advanced Features
 
 ```bash
 # Add timestamp to output filename
-jc -c gzip -t 2 file.txt
+jcz -c gzip -t 2 file.txt
 # Output: file.txt_20251101_121019.gz
 
 # Move compressed files to directory
-jc -c gzip -C /backups/ *.txt
+jcz -c gzip -C /backups/ *.txt
 
 # Collect files into archive with parent directory
-jc -c tgz -a myarchive file1.txt file2.txt dir/
+jcz -c tgz -a myarchive file1.txt file2.txt dir/
 
 # Collect files without parent directory wrapper
-jc -c tgz -A myarchive file1.txt file2.txt
+jcz -c tgz -A myarchive file1.txt file2.txt
 ```
 
 ### Options
@@ -109,7 +109,7 @@ jc -c tgz -A myarchive file1.txt file2.txt
   - `debug` - Show all log messages including debug
 
 ```bash
-JCDBG=debug jc -c gzip file.txt
+JCDBG=debug jcz -c gzip file.txt
 ```
 
 ## Architecture
@@ -144,13 +144,10 @@ The implementation follows a modular design:
 
 ## Documentation
 
-- [Software Requirements Specification](docs/jc_srs.md)
-- [Software Design Document](docs/jc_sdd.md)
+- [Software Requirements Specification](docs/jcz_srs.md)
+- [Software Design Document](docs/jcz_sdd.md)
 
 ## License
 
 MIT
 
-## Original Implementation
-
-This is a Rust reimplementation of the original Go version available at https://github.com/saimizi/jc

--- a/docs/jcz_sdd.md
+++ b/docs/jcz_sdd.md
@@ -1,5 +1,5 @@
 # Software Design Document (SDD)
-## JC - Just Compress Utility (Rust Implementation)
+## JCZ - Just Compress Zip Utility (Rust Implementation)
 
 **Version:** 1.0
 **Date:** 2025-11-01
@@ -11,7 +11,7 @@
 ## 1. Introduction
 
 ### 1.1 Purpose
-This Software Design Document describes the architecture, design, and implementation strategy for the JC (Just Compress) utility in Rust. It provides detailed technical specifications for developers implementing the system.
+This Software Design Document describes the architecture, design, and implementation strategy for the JCZ (Just Compress Zip) utility in Rust. It provides detailed technical specifications for developers implementing the system.
 
 ### 1.2 Scope
 This document covers:
@@ -24,7 +24,7 @@ This document covers:
 - Testing approach
 
 ### 1.3 References
-- JC Software Requirements Specification (jc_srs.md)
+- JCZ Software Requirements Specification (jcz_srs.md)
 - Rust Programming Language Documentation
 - The Rust Book (https://doc.rust-lang.org/book/)
 - Rust API Guidelines (https://rust-lang.github.io/api-guidelines/)
@@ -94,7 +94,7 @@ This document covers:
 ### 2.2 Module Structure
 
 ```
-jc/
+jcz/
 ├── src/
 │   ├── main.rs                 # Entry point, CLI setup
 │   ├── lib.rs                  # Library root, public API
@@ -132,8 +132,8 @@ jc/
 │   └── fixtures/               # Test data
 ├── Cargo.toml                  # Dependencies and metadata
 └── docs/
-    ├── jc_srs.md               # Requirements specification
-    └── jc_sdd.md               # This design document
+    ├── jcz_srs.md              # Requirements specification
+    └── jcz_sdd.md              # This design document
 ```
 
 ---
@@ -309,10 +309,10 @@ use std::fmt;
 use std::io;
 use std::path::PathBuf;
 
-/// Result type for JC operations
+/// Result type for JCZ operations
 pub type JcResult<T> = Result<T, JcError>;
 
-/// Comprehensive error type for JC operations
+/// Comprehensive error type for JCZ operations
 #[derive(Debug)]
 pub enum JcError {
     /// File not found
@@ -1372,7 +1372,7 @@ pub fn collect_and_compress(
     info!("Collecting {} files into {}", inputs.len(), collection_config.package_name);
 
     // Create temporary staging directory
-    let temp_dir = fsutil::create_temp_dir("jcpkg_")?;
+    let temp_dir = fsutil::create_temp_dir("jczpkg_")?;
     debug!("Created temporary directory: {}", temp_dir.display());
 
     // Ensure cleanup on exit
@@ -1502,17 +1502,17 @@ use log::{Level, LevelFilter};
 
 static LOGGER_INIT: OnceLock<()> = OnceLock::new();
 
-/// Initialize the logging system based on JCDBG environment variable
+/// Initialize the logging system based on JCZDBG environment variable
 pub fn init_logger() {
     LOGGER_INIT.get_or_init(|| {
         let env = Env::default()
-            .filter_or("JCDBG", "info")
-            .write_style("JCDBG_STYLE");
+            .filter_or("JCZDBG", "info")
+            .write_style("JCZDBG_STYLE");
 
         let mut builder = Builder::from_env(env);
 
-        // Map JCDBG values to log levels
-        let level = std::env::var("JCDBG")
+        // Map JCZDBG values to log levels
+        let level = std::env::var("JCZDBG")
             .ok()
             .and_then(|val| match val.to_lowercase().as_str() {
                 "error" => Some(LevelFilter::Error),
@@ -1537,7 +1537,7 @@ pub use log::{debug, error, info, warn};
 
 **Design Rationale**:
 - **env_logger crate**: Standard Rust logging
-- **JCDBG variable**: Match original behavior
+- **JCZDBG variable**: Match original behavior
 - **OnceLock**: Thread-safe initialization
 - **Re-export macros**: Convenient imports
 
@@ -1854,7 +1854,7 @@ pub fn validate_move_to(path: &Path) -> JcResult<()> {
 
     // Check if writable by attempting to create a test file
     // (More robust than checking permissions)
-    let test_file = path.join(".jc_write_test");
+    let test_file = path.join(".jcz_write_test");
     match fs::File::create(&test_file) {
         Ok(_) => {
             let _ = fs::remove_file(&test_file);
@@ -1878,10 +1878,10 @@ use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
-#[command(name = "jc")]
-#[command(author = "JC Contributors")]
+#[command(name = "jcz")]
+#[command(author = "JCZ Contributors")]
 #[command(version)]
-#[command(about = "Just Compress - A unified compression utility", long_about = None)]
+#[command(about = "Just Compress Zip - A unified compression utility", long_about = None)]
 pub struct CliArgs {
     /// Decompress mode
     #[arg(short = 'd', long)]
@@ -2134,13 +2134,13 @@ fn main() {
 
 ```toml
 [package]
-name = "jc"
+name = "jcz"
 version = "0.1.0"
 edition = "2021"
-authors = ["JC Contributors"]
-description = "Just Compress - A unified compression utility"
+authors = ["JCZ Contributors"]
+description = "Just Compress Zip - A unified compression utility"
 license = "MIT"
-repository = "https://github.com/saimizi/jc"
+repository = "https://github.com/saimizi/jcz"
 
 [dependencies]
 # Command-line argument parsing
@@ -2163,7 +2163,7 @@ assert_cmd = "2.0"
 predicates = "3.0"
 
 [[bin]]
-name = "jc"
+name = "jcz"
 path = "src/main.rs"
 
 [profile.release]
@@ -2224,7 +2224,7 @@ fn test_compress_gzip() {
     let input_file = temp.path().join("test.txt");
     fs::write(&input_file, b"Hello, world!").unwrap();
 
-    let mut cmd = Command::cargo_bin("jc").unwrap();
+    let mut cmd = Command::cargo_bin("jcz").unwrap();
     cmd.arg("-c").arg("gzip")
        .arg(&input_file)
        .current_dir(temp.path());
@@ -2259,8 +2259,8 @@ fn test_decompress_gzip() {
 
     let compressed = temp.path().join("test.txt.gz");
 
-    // Decompress with jc
-    let mut cmd = Command::cargo_bin("jc").unwrap();
+    // Decompress with jcz
+    let mut cmd = Command::cargo_bin("jcz").unwrap();
     cmd.arg("-d")
        .arg(&compressed)
        .current_dir(temp.path());
@@ -2292,7 +2292,7 @@ fn test_decompress_gzip() {
 cargo build
 
 # Run with debug logging
-JCDBG=debug cargo run -- -c gzip test.txt
+JCZDBG=debug cargo run -- -c gzip test.txt
 
 # Run tests
 cargo test

--- a/docs/jcz_srs.md
+++ b/docs/jcz_srs.md
@@ -1,5 +1,5 @@
 # Software Requirements Specification (SRS)
-## JC - Just Compress Utility
+## JCZ - Just Compress Zip Utility
 
 **Version:** 1.0
 **Date:** 2025-11-01
@@ -10,10 +10,10 @@
 ## 1. Introduction
 
 ### 1.1 Purpose
-This document specifies the functional and non-functional requirements for JC (Just Compress), a command-line compression utility that provides a unified interface for multiple compression formats.
+This document specifies the functional and non-functional requirements for JCZ (Just Compress Zip), a command-line compression utility that provides a unified interface for multiple compression formats.
 
 ### 1.2 Scope
-JC is a command-line tool that simplifies file and directory compression/decompression operations. It supports multiple compression algorithms (GZIP, BZIP2, XZ) and archive formats (TAR), including compound formats (TAR+GZIP, TAR+BZIP2, TAR+XZ).
+JCZ is a command-line tool that simplifies file and directory compression/decompression operations. It supports multiple compression algorithms (GZIP, BZIP2, XZ) and archive formats (TAR), including compound formats (TAR+GZIP, TAR+BZIP2, TAR+XZ).
 
 ### 1.3 Intended Audience
 - Software developers implementing the tool
@@ -22,7 +22,7 @@ JC is a command-line tool that simplifies file and directory compression/decompr
 - System administrators
 
 ### 1.4 Definitions and Acronyms
-- **JC**: Just Compress
+- **JCZ**: Just Compress Zip
 - **CLI**: Command-Line Interface
 - **GZIP**: GNU Zip compression algorithm
 - **BZIP2**: Burrows-Wheeler compression algorithm
@@ -37,7 +37,7 @@ JC is a command-line tool that simplifies file and directory compression/decompr
 ## 2. Overall Description
 
 ### 2.1 Product Perspective
-JC is a standalone command-line utility that wraps system compression tools (gzip, bzip2, xz, tar) to provide a consistent, simplified interface. It acts as a compression abstraction layer, allowing users to compress/decompress files without memorizing different command syntaxes for each compression tool.
+JCZ is a standalone command-line utility that wraps system compression tools (gzip, bzip2, xz, tar) to provide a consistent, simplified interface. It acts as a compression abstraction layer, allowing users to compress/decompress files without memorizing different command syntaxes for each compression tool.
 
 ### 2.2 Product Features
 1. **Multi-Format Compression**: Support for GZIP, BZIP2, XZ, TAR, TGZ, TBZ2, TXZ
@@ -353,9 +353,9 @@ JC is a standalone command-line utility that wraps system compression tools (gzi
 - All extracted files in correct locations
 
 **Examples**:
-- `jc -d multi.tar.gz -C output/` → files in `output/file1.txt`, `output/file2.txt`
-- `jc -d multi.tar.gz` → files in `multi/file1.txt`, `multi/file2.txt`
-- `jc -d single.tar.gz -C output/` → file in `output/single.txt`
+- `jcz -d multi.tar.gz -C output/` → files in `output/file1.txt`, `output/file2.txt`
+- `jcz -d multi.tar.gz` → files in `multi/file1.txt`, `multi/file2.txt`
+- `jcz -d single.tar.gz -C output/` → file in `output/single.txt`
 
 **Error Conditions**:
 - Corrupted TAR archive
@@ -469,16 +469,16 @@ JC is a standalone command-line utility that wraps system compression tools (gzi
 1. **ERROR**: Critical errors (always enabled)
 2. **WARN**: Warnings (enabled by default)
 3. **INFO**: Informational messages (enabled by default)
-4. **DEBUG**: Debug messages (enabled only when `JCDBG=debug`)
+4. **DEBUG**: Debug messages (enabled only when `JCZDBG=debug`)
 
 **Requirements**:
 - ERROR logs shall include file location (short filename)
 - DEBUG logs shall include file location (short filename)
 - Log output shall go to STDERR
 - Disabled log levels shall output to /dev/null
-- Environment variable `JCDBG` shall control logging verbosity
+- Environment variable `JCZDBG` shall control logging verbosity
 
-**JCDBG Environment Variable Values**:
+**JCZDBG Environment Variable Values**:
 - `error`: Only error logs
 - `warn`: Error and warning logs
 - `info`: Error, warning, and info logs (default behavior)
@@ -508,7 +508,7 @@ JC is a standalone command-line utility that wraps system compression tools (gzi
 
 **Command Syntax**:
 ```
-jc [Options] <File|Dir> [File|Dir]...
+jcz [Options] <File|Dir> [File|Dir]...
 ```
 
 **Options**:
@@ -568,7 +568,7 @@ jc [Options] <File|Dir> [File|Dir]...
 
 **Requirements**:
 - Temporary directories shall be created in current directory
-- Temporary directory naming: `jcpkg_<random>`
+- Temporary directory naming: `jczpkg_<random>`
 - Temporary files shall be cleaned up on completion
 - File permissions shall be preserved (0755 for created files)
 
@@ -1017,7 +1017,7 @@ Combine multiple files/directories into a single compressed archive.
    - Verify no duplicate basenames
 
 2. **Staging**:
-   - Create temporary directory: `jcpkg_<random>` in current directory
+   - Create temporary directory: `jczpkg_<random>` in current directory
    - Create subdirectory: `<tmpdir>/<pkgname>`
    - Copy all input files to staging directory: `cp -r <file> <staging>/`
 
@@ -1099,7 +1099,7 @@ Process multiple files concurrently with parallelism.
 - gzip tool is installed
 
 **Main Flow**:
-1. User executes: `jc -c gzip myfile.txt`
+1. User executes: `jcz -c gzip myfile.txt`
 2. System validates input file
 3. System creates compressor configuration
 4. System compresses file to `myfile.txt.gz`
@@ -1120,7 +1120,7 @@ Process multiple files concurrently with parallelism.
 - tar and gzip tools installed
 
 **Main Flow**:
-1. User executes: `jc -c tgz -a myarchive file1.txt file2.txt dir1/`
+1. User executes: `jcz -c tgz -a myarchive file1.txt file2.txt dir1/`
 2. System validates input files
 3. System checks for duplicate basenames
 4. System creates temporary directory
@@ -1145,7 +1145,7 @@ Process multiple files concurrently with parallelism.
 - gzip and tar tools installed
 
 **Main Flow**:
-1. User executes: `jc -d archive.tar.gz`
+1. User executes: `jcz -d archive.tar.gz`
 2. System detects .gz extension
 3. System decompresses GZIP layer to `archive.tar`
 4. System detects .tar extension
@@ -1168,7 +1168,7 @@ Process multiple files concurrently with parallelism.
 - bzip2 tool installed
 
 **Main Flow**:
-1. User executes: `jc -c bzip2 -t 2 -C /backups/ important.doc`
+1. User executes: `jcz -c bzip2 -t 2 -C /backups/ important.doc`
 2. System validates input file
 3. System validates destination directory
 4. System generates timestamp (e.g., 20251101_143522)
@@ -1189,7 +1189,7 @@ Process multiple files concurrently with parallelism.
 - xz tool installed
 
 **Main Flow**:
-1. User executes: `jc -c xz -l 9 file1.txt file2.txt file3.txt`
+1. User executes: `jcz -c xz -l 9 file1.txt file2.txt file3.txt`
 2. System validates input files
 3. System creates XZ compressor with level 9
 4. System spawns 3 concurrent compression operations
@@ -1333,53 +1333,53 @@ Process multiple files concurrently with parallelism.
 
 | Variable | Values | Default | Purpose |
 |----------|--------|---------|---------|
-| JCDBG | error, warn, info, debug | info | Control logging verbosity |
+| JCZDBG | error, warn, info, debug | info | Control logging verbosity |
 
 ### Appendix E: Temporary File Naming
 
 | Type | Pattern | Example |
 |------|---------|---------|
-| Staging directory | `jcpkg_<random>` | `jcpkg_a8f3d2b1` |
+| Staging directory | `jczpkg_<random>` | `jczpkg_a8f3d2b1` |
 | Intermediate TAR | `<original>.tar` | `myfile.txt.tar` |
 
 ### Appendix F: Command Examples
 
 ```bash
 # Basic compression
-jc -c gzip myfile.txt
+jcz -c gzip myfile.txt
 
 # Compression with level
-jc -c bzip2 -l 9 large.iso
+jcz -c bzip2 -l 9 large.iso
 
 # Create compressed archive
-jc -c tgz -a backup file1 file2 dir/
+jcz -c tgz -a backup file1 file2 dir/
 
 # Create flat archive (no parent directory)
-jc -c txz -A backup file1 file2 dir/
+jcz -c txz -A backup file1 file2 dir/
 
 # Compress with timestamp
-jc -c xz -t 2 document.pdf
+jcz -c xz -t 2 document.pdf
 
 # Compress and move to directory
-jc -c gzip -C /backups/ important.doc
+jcz -c gzip -C /backups/ important.doc
 
 # Compress with all options
-jc -c bzip2 -l 9 -t 2 -C /archives/ file.bin
+jcz -c bzip2 -l 9 -t 2 -C /archives/ file.bin
 
 # Decompress single file
-jc -d archive.tar.gz
+jcz -d archive.tar.gz
 
 # Decompress and move
-jc -d -C /extracted/ archive.tar.xz
+jcz -d -C /extracted/ archive.tar.xz
 
 # Batch compress
-jc -c gzip *.txt
+jcz -c gzip *.txt
 
 # Batch decompress
-jc -d *.gz
+jcz -d *.gz
 
 # Enable debug logging
-JCDBG=debug jc -c gzip myfile.txt
+JCZDBG=debug jcz -c gzip myfile.txt
 ```
 
 ---

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,10 +2,10 @@ use clap::Parser;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
-#[command(name = "jc")]
-#[command(author = "JC Contributors")]
+#[command(name = "jcz")]
+#[command(author = "JCZ Contributors")]
 #[command(version)]
-#[command(about = "Just Compress - A unified compression utility", long_about = None)]
+#[command(about = "Just Compress Zip - A unified compression utility", long_about = None)]
 pub struct CliArgs {
     /// Decompress mode
     #[arg(short = 'd', long)]

--- a/src/operations/collection.rs
+++ b/src/operations/collection.rs
@@ -53,7 +53,7 @@ pub fn collect_and_compress(
     );
 
     // Create temporary staging directory
-    let temp_dir = create_temp_dir("jcpkg_")?;
+    let temp_dir = create_temp_dir("jczpkg_")?;
     debug!("Created temporary directory: {}", temp_dir.display());
 
     // Ensure cleanup on exit

--- a/src/utils/validation.rs
+++ b/src/utils/validation.rs
@@ -106,7 +106,7 @@ pub fn validate_move_to(path: &Path) -> JcResult<()> {
     }
 
     // Check if writable by attempting to create a test file
-    let test_file = path.join(".jc_write_test");
+    let test_file = path.join(".jcz_write_test");
     match fs::File::create(&test_file) {
         Ok(_) => {
             let _ = fs::remove_file(&test_file);

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Integration Tests
 
-This directory contains integration tests for the `jc` (Just Compress) command-line tool.
+This directory contains integration tests for the `jcz` (Just Compress Zip) command-line tool.
 
 ## Prerequisites
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,10 +19,10 @@ pub fn create_test_files(dir: &Path, files: &[(&str, &[u8])]) -> Vec<PathBuf> {
         .collect()
 }
 
-/// Helper to create a jc command
-pub fn jc_command() -> Command {
+/// Helper to create a jcz command
+pub fn jcz_command() -> Command {
     #[allow(deprecated)]
-    Command::cargo_bin("jc").expect("Failed to find jc binary")
+    Command::cargo_bin("jcz").expect("Failed to find jcz binary")
 }
 
 /// Helper to verify a file exists

--- a/tests/test_bzip2.rs
+++ b/tests/test_bzip2.rs
@@ -8,7 +8,7 @@ fn test_bzip2_compress_single_file() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg(&test_file)
@@ -34,7 +34,7 @@ fn test_bzip2_compress_multiple_files() {
         ],
     );
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .args(&files)
@@ -52,7 +52,7 @@ fn test_bzip2_compress_with_level_1() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg("-l")
@@ -70,7 +70,7 @@ fn test_bzip2_compress_with_level_9() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg("-l")
@@ -88,7 +88,7 @@ fn test_bzip2_compress_with_default_level() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg(&test_file)
@@ -105,7 +105,7 @@ fn test_bzip2_decompress_single_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // First compress
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg(&test_file)
@@ -119,7 +119,7 @@ fn test_bzip2_decompress_single_file() {
     std::fs::remove_file(&test_file).unwrap();
 
     // Now decompress
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .assert()
@@ -145,7 +145,7 @@ fn test_bzip2_decompress_multiple_files() {
     );
 
     // Compress both files
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .args(&files)
@@ -160,7 +160,7 @@ fn test_bzip2_decompress_multiple_files() {
     std::fs::remove_file(&files[1]).unwrap();
 
     // Decompress both
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&bz1)
         .arg(&bz2)
@@ -178,7 +178,7 @@ fn test_bzip2_compress_binary_data() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "binary.dat", TEST_DATA_BINARY);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg(&test_file)
@@ -190,7 +190,7 @@ fn test_bzip2_compress_binary_data() {
 
     // Verify decompression works
     std::fs::remove_file(&test_file).unwrap();
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .assert()
@@ -211,7 +211,7 @@ fn test_bzip2_verify_compression_reduces_size() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", compressible_content.as_bytes());
     let original_size = file_size(&test_file);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg(&test_file)
@@ -233,7 +233,7 @@ fn test_bzip2_compress_preserves_original() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
     let original_content = read_file(&test_file);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg(&test_file)

--- a/tests/test_compound.rs
+++ b/tests/test_compound.rs
@@ -10,7 +10,7 @@ fn test_tgz_compress_single_file() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg(&test_file)
@@ -27,7 +27,7 @@ fn test_tgz_compress_with_level_1() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-l")
@@ -45,7 +45,7 @@ fn test_tgz_compress_with_level_9() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-l")
@@ -64,7 +64,7 @@ fn test_tgz_decompress_single_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Compress
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg(&test_file)
@@ -77,7 +77,7 @@ fn test_tgz_decompress_single_file() {
     std::fs::remove_file(&test_file).unwrap();
 
     // Decompress
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .assert()
@@ -94,7 +94,7 @@ fn test_tgz_default_command() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // tgz is the default, so omitting -c should use tgz
-    jc_command().arg(&test_file).assert().success();
+    jcz_command().arg(&test_file).assert().success();
 
     let compressed_file = temp_dir.path().join("test.txt.tar.gz");
     assert!(
@@ -110,7 +110,7 @@ fn test_tbz2_compress_single_file() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tbz2")
         .arg(&test_file)
@@ -127,7 +127,7 @@ fn test_tbz2_compress_with_level_1() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tbz2")
         .arg("-l")
@@ -145,7 +145,7 @@ fn test_tbz2_compress_with_level_9() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tbz2")
         .arg("-l")
@@ -164,7 +164,7 @@ fn test_tbz2_decompress_single_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Compress
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tbz2")
         .arg(&test_file)
@@ -177,7 +177,7 @@ fn test_tbz2_decompress_single_file() {
     std::fs::remove_file(&test_file).unwrap();
 
     // Decompress
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .assert()
@@ -195,7 +195,7 @@ fn test_txz_compress_single_file() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg(&test_file)
@@ -212,7 +212,7 @@ fn test_txz_compress_with_level_1() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg("-l")
@@ -230,7 +230,7 @@ fn test_txz_compress_with_level_9() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg("-l")
@@ -249,7 +249,7 @@ fn test_txz_decompress_single_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Compress
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg(&test_file)
@@ -262,7 +262,7 @@ fn test_txz_decompress_single_file() {
     std::fs::remove_file(&test_file).unwrap();
 
     // Decompress
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .assert()
@@ -280,7 +280,7 @@ fn test_tgz_verify_is_gzip_compressed() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg(&test_file)
@@ -302,7 +302,7 @@ fn test_tbz2_verify_is_bzip2_compressed() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tbz2")
         .arg(&test_file)
@@ -324,7 +324,7 @@ fn test_txz_verify_is_xz_compressed() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg(&test_file)
@@ -354,7 +354,7 @@ fn test_compound_formats_preserve_originals() {
     let original_content = read_file(&test_file);
 
     // Test TGZ
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg(&test_file)
@@ -363,7 +363,7 @@ fn test_compound_formats_preserve_originals() {
     assert_eq!(read_file(&test_file), original_content);
 
     // Test TBZ2
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tbz2")
         .arg(&test_file)
@@ -372,7 +372,7 @@ fn test_compound_formats_preserve_originals() {
     assert_eq!(read_file(&test_file), original_content);
 
     // Test TXZ
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg(&test_file)
@@ -390,7 +390,7 @@ fn test_tgz_compress_multiple_files_with_archive_flag() {
     let file2 = create_test_file(temp_dir.path(), "file2.txt", b"Content 2");
     let file3 = create_test_file(temp_dir.path(), "file3.txt", b"Content 3");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-A")
@@ -421,7 +421,7 @@ fn test_tbz2_compress_multiple_files_with_archive_flag() {
     let file2 = create_test_file(temp_dir.path(), "file2.txt", b"Content 2");
     let file3 = create_test_file(temp_dir.path(), "file3.txt", b"Content 3");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tbz2")
         .arg("-A")
@@ -452,7 +452,7 @@ fn test_txz_compress_multiple_files_with_archive_flag() {
     let file2 = create_test_file(temp_dir.path(), "file2.txt", b"Content 2");
     let file3 = create_test_file(temp_dir.path(), "file3.txt", b"Content 3");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg("-A")
@@ -494,7 +494,7 @@ fn test_multiple_files_archive_with_destination_directory() {
     let file2 = create_test_file(&source_dir, "b.txt", b"Content B");
     let file3 = create_test_file(&source_dir, "c.txt", b"Content C");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg("-A")
@@ -522,7 +522,7 @@ fn test_multiple_files_archive_can_be_extracted() {
     let file3 = create_test_file(temp_dir.path(), "file3.txt", b"Content 3");
 
     // Create archive
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-A")

--- a/tests/test_compression.rs
+++ b/tests/test_compression.rs
@@ -15,7 +15,7 @@ fn test_compress_with_auto_create_directory() {
     assert!(!dest_dir.exists());
 
     // Compress with -C to non-existent directory (should auto-create)
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -49,7 +49,7 @@ fn test_compress_with_nested_directory_creation() {
     assert!(!dest_dir.exists());
 
     // Compress to nested path
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg("-C")
@@ -75,7 +75,7 @@ fn test_cross_device_compress_with_c_flag() {
     fs::create_dir(&dest_dir).unwrap();
 
     // Compress with -C to different location
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -104,7 +104,7 @@ fn test_compress_multiple_files_with_c_flag() {
     let dest_dir = temp_dir.path().join("compressed");
 
     // Compress multiple files to destination
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg("-C")
@@ -134,7 +134,7 @@ fn test_compress_compound_format_with_c_flag() {
     let dest_dir = temp_dir.path().join("archives");
 
     // Test tar.gz
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-C")
@@ -147,7 +147,7 @@ fn test_compress_compound_format_with_c_flag() {
     assert!(file_exists(&dest_dir.join("test.txt.tar.gz")));
 
     // Test tar.bz2
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tbz2")
         .arg("-C")
@@ -159,7 +159,7 @@ fn test_compress_compound_format_with_c_flag() {
     assert!(file_exists(&dest_dir.join("test.txt.tar.bz2")));
 
     // Test tar.xz
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg("-C")
@@ -182,7 +182,7 @@ fn test_compress_to_existing_directory() {
     fs::create_dir(&dest_dir).unwrap();
 
     // Compress to existing directory
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -203,7 +203,7 @@ fn test_compress_with_c_flag_and_levels() {
     let dest_dir = temp_dir.path().join("compressed");
 
     // Test with level 1
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-l")
@@ -222,7 +222,7 @@ fn test_compress_with_c_flag_and_levels() {
     fs::remove_file(&compressed_file).unwrap();
 
     // Test with level 9
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-l")
@@ -245,7 +245,7 @@ fn test_compress_with_c_flag_preserves_original() {
 
     let dest_dir = temp_dir.path().join("output");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -275,7 +275,7 @@ fn test_compress_with_c_flag_and_timestamp() {
     let dest_dir = temp_dir.path().join("timestamped");
 
     // Compress with timestamp option
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-t")
@@ -310,7 +310,7 @@ fn test_concurrent_compress_with_different_destinations() {
     let dest2 = temp_dir.path().join("dest2");
 
     // Compress first file to dest1
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -320,7 +320,7 @@ fn test_concurrent_compress_with_different_destinations() {
         .success();
 
     // Compress second file to dest2
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg("-C")
@@ -342,7 +342,7 @@ fn test_compress_binary_data_with_c_flag() {
 
     let dest_dir = temp_dir.path().join("binary_output");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg("-C")

--- a/tests/test_decompression.rs
+++ b/tests/test_decompression.rs
@@ -11,7 +11,7 @@ fn test_decompress_with_auto_create_directory() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // First compress the file
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -29,7 +29,7 @@ fn test_decompress_with_auto_create_directory() {
     assert!(!dest_dir.exists(), "Destination should not exist initially");
 
     // Decompress to non-existent directory (should auto-create)
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .arg("-C")
@@ -60,7 +60,7 @@ fn test_decompress_with_nested_directory_creation() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Compress the file
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -75,7 +75,7 @@ fn test_decompress_with_nested_directory_creation() {
     assert!(!dest_dir.exists());
 
     // Decompress to nested path
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .arg("-C")
@@ -95,7 +95,7 @@ fn test_decompress_with_force_flag() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Compress the file
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -105,7 +105,7 @@ fn test_decompress_with_force_flag() {
     let compressed_file = temp_dir.path().join("test.txt.gz");
 
     // Decompress first time
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .arg("-f")
@@ -118,7 +118,7 @@ fn test_decompress_with_force_flag() {
     assert_eq!(read_file(&decompressed_file), b"Modified content");
 
     // Decompress again with --force (should overwrite without prompt)
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .arg("-f")
@@ -136,7 +136,7 @@ fn test_decompress_compound_format_single_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
     // Compress to .tar.gz
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg(&test_file)
@@ -149,7 +149,7 @@ fn test_decompress_compound_format_single_file() {
     // Remove original and decompress
     fs::remove_file(&test_file).unwrap();
 
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .arg("-f")
@@ -169,7 +169,7 @@ fn test_decompress_to_different_directory_with_c_flag() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Compress the file
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg(&test_file)
@@ -187,7 +187,7 @@ fn test_decompress_to_different_directory_with_c_flag() {
     fs::remove_file(&test_file).unwrap();
 
     // Decompress to different directory with -C flag
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .arg("-C")
@@ -211,7 +211,7 @@ fn test_concurrent_decompress_no_conflicts() {
     let file2 = create_test_file(temp_dir.path(), "test2.txt", TEST_DATA_MEDIUM);
     let file3 = create_test_file(temp_dir.path(), "test3.txt", TEST_DATA_BINARY);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .args(&[&file1, &file2, &file3])
@@ -228,7 +228,7 @@ fn test_concurrent_decompress_no_conflicts() {
     fs::remove_file(&file3).unwrap();
 
     // Decompress all files concurrently (should not conflict due to temp directory isolation)
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed1)
         .arg(&compressed2)
@@ -262,7 +262,7 @@ fn test_decompress_tar_bz2() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
     // Compress to .tar.bz2
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tbz2")
         .arg(&test_file)
@@ -275,7 +275,7 @@ fn test_decompress_tar_bz2() {
     fs::remove_file(&test_file).unwrap();
 
     // Decompress
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .arg("-f")
@@ -294,7 +294,7 @@ fn test_decompress_tar_xz() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
     // Compress to .tar.xz
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg(&test_file)
@@ -307,7 +307,7 @@ fn test_decompress_tar_xz() {
     fs::remove_file(&test_file).unwrap();
 
     // Decompress
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .arg("-f")
@@ -326,21 +326,21 @@ fn test_decompress_mixed_formats() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
     // Compress with different formats
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
         .assert()
         .success();
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("bzip2")
         .arg(&test_file)
         .assert()
         .success();
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg(&test_file)
@@ -355,7 +355,7 @@ fn test_decompress_mixed_formats() {
     fs::remove_file(&test_file).unwrap();
 
     // Decompress gz first
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&gz_file)
         .arg("-f")
@@ -366,7 +366,7 @@ fn test_decompress_mixed_formats() {
     assert_eq!(read_file(&test_file), TEST_DATA_MEDIUM);
 
     // Decompress bz2 (should overwrite with force flag)
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&bz2_file)
         .arg("-f")
@@ -376,7 +376,7 @@ fn test_decompress_mixed_formats() {
     assert_eq!(read_file(&test_file), TEST_DATA_MEDIUM);
 
     // Decompress xz (should overwrite with force flag)
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&xz_file)
         .arg("-f")
@@ -393,7 +393,7 @@ fn test_cross_device_move_with_c_flag() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Compress the file
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -407,7 +407,7 @@ fn test_cross_device_move_with_c_flag() {
     let dest_dir = dest_temp_dir.path().join("output");
 
     // Decompress with -C to different location
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .arg("-C")
@@ -430,7 +430,7 @@ fn test_decompress_preserves_binary_content() {
 
     // Compress with each algorithm
     for format in &["gzip", "bzip2", "xz"] {
-        jc_command()
+        jcz_command()
             .arg("-c")
             .arg(format)
             .arg(&test_file)
@@ -450,7 +450,7 @@ fn test_decompress_preserves_binary_content() {
         // Decompress
         fs::remove_file(&test_file).unwrap();
 
-        jc_command()
+        jcz_command()
             .arg("-d")
             .arg(&compressed_file)
             .arg("-f")

--- a/tests/test_errors.rs
+++ b/tests/test_errors.rs
@@ -10,7 +10,7 @@ fn test_invalid_compression_command() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("invalid")
         .arg(&test_file)
@@ -23,7 +23,7 @@ fn test_invalid_compression_level_zero() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-l")
@@ -38,7 +38,7 @@ fn test_invalid_compression_level_too_high() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-l")
@@ -53,7 +53,7 @@ fn test_invalid_timestamp_option_negative() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-t")
@@ -68,7 +68,7 @@ fn test_invalid_timestamp_option_too_high() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-t")
@@ -85,7 +85,7 @@ fn test_nonexistent_file() {
     let temp_dir = TempDir::new().unwrap();
     let nonexistent = temp_dir.path().join("does_not_exist.txt");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&nonexistent)
@@ -98,7 +98,7 @@ fn test_decompress_nonexistent_file() {
     let temp_dir = TempDir::new().unwrap();
     let nonexistent = temp_dir.path().join("does_not_exist.gz");
 
-    jc_command().arg("-d").arg(&nonexistent).assert().failure();
+    jcz_command().arg("-d").arg(&nonexistent).assert().failure();
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn test_multiple_files_with_one_missing() {
     let test_file = create_test_file(temp_dir.path(), "exists.txt", TEST_DATA_SMALL);
     let nonexistent = temp_dir.path().join("does_not_exist.txt");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -120,12 +120,12 @@ fn test_multiple_files_with_one_missing() {
 
 #[test]
 fn test_no_input_files() {
-    jc_command().arg("-c").arg("gzip").assert().failure();
+    jcz_command().arg("-c").arg("gzip").assert().failure();
 }
 
 #[test]
 fn test_decompress_no_input_files() {
-    jc_command().arg("-d").assert().failure();
+    jcz_command().arg("-d").assert().failure();
 }
 
 // Invalid Directory Tests
@@ -137,7 +137,7 @@ fn test_move_to_nonexistent_directory_auto_creates() {
     let nonexistent_dir = temp_dir.path().join("does_not_exist");
 
     // Should auto-create the directory and succeed
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -157,7 +157,7 @@ fn test_move_to_file_instead_of_directory() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
     let not_a_dir = create_test_file(temp_dir.path(), "not_a_dir.txt", b"content");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -175,7 +175,7 @@ fn test_collect_without_archive_name() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Using -a flag requires an argument
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-a")
@@ -191,7 +191,7 @@ fn test_decompress_invalid_gzip_file() {
     let temp_dir = TempDir::new().unwrap();
     let fake_gz = create_test_file(temp_dir.path(), "fake.gz", b"not a gzip file");
 
-    jc_command().arg("-d").arg(&fake_gz).assert().failure();
+    jcz_command().arg("-d").arg(&fake_gz).assert().failure();
 }
 
 #[test]
@@ -200,7 +200,7 @@ fn test_decompress_corrupted_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // First create a valid compressed file
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -218,7 +218,7 @@ fn test_decompress_corrupted_file() {
     std::fs::remove_file(&test_file).unwrap();
 
     // Try to decompress corrupted file
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .assert()
@@ -235,7 +235,7 @@ fn test_compress_directory_without_collection() {
     create_test_file(&test_dir, "file.txt", TEST_DATA_SMALL);
 
     // Trying to compress a directory without collection should fail or handle appropriately
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_dir)
@@ -250,7 +250,7 @@ fn test_empty_file() {
     let temp_dir = TempDir::new().unwrap();
     let empty_file = create_test_file(temp_dir.path(), "empty.txt", b"");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&empty_file)
@@ -273,7 +273,7 @@ fn test_file_with_special_characters_in_name() {
         TEST_DATA_SMALL,
     );
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&special_file)
@@ -292,7 +292,7 @@ fn test_file_with_multiple_dots() {
     let temp_dir = TempDir::new().unwrap();
     let dotted_file = create_test_file(temp_dir.path(), "file.tar.backup.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&dotted_file)
@@ -312,7 +312,7 @@ fn test_already_compressed_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Compress once
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -322,7 +322,7 @@ fn test_already_compressed_file() {
     let compressed_file = temp_dir.path().join("test.txt.gz");
 
     // Try to compress the .gz file (should work, creating .gz.gz)
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&compressed_file)
@@ -344,7 +344,7 @@ fn test_decompress_file_with_wrong_extension() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Compress with gzip
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -357,6 +357,6 @@ fn test_decompress_file_with_wrong_extension() {
     let wrong_ext = temp_dir.path().join("test.txt.bz2");
     std::fs::rename(&compressed_file, &wrong_ext).unwrap();
 
-    // Try to decompress - jc decompresses based on extension, so this should fail
-    jc_command().arg("-d").arg(&wrong_ext).assert().failure();
+    // Try to decompress - jcz decompresses based on extension, so this should fail
+    jcz_command().arg("-d").arg(&wrong_ext).assert().failure();
 }

--- a/tests/test_gzip.rs
+++ b/tests/test_gzip.rs
@@ -8,7 +8,7 @@ fn test_gzip_compress_single_file() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -34,7 +34,7 @@ fn test_gzip_compress_multiple_files() {
         ],
     );
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .args(&files)
@@ -52,7 +52,7 @@ fn test_gzip_compress_with_level_1() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-l")
@@ -70,7 +70,7 @@ fn test_gzip_compress_with_level_9() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-l")
@@ -88,7 +88,7 @@ fn test_gzip_compress_with_default_level() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -105,7 +105,7 @@ fn test_gzip_decompress_single_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // First compress
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -119,7 +119,7 @@ fn test_gzip_decompress_single_file() {
     std::fs::remove_file(&test_file).unwrap();
 
     // Now decompress
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .assert()
@@ -145,7 +145,7 @@ fn test_gzip_decompress_multiple_files() {
     );
 
     // Compress both files
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .args(&files)
@@ -160,7 +160,7 @@ fn test_gzip_decompress_multiple_files() {
     std::fs::remove_file(&files[1]).unwrap();
 
     // Decompress both
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&gz1)
         .arg(&gz2)
@@ -178,7 +178,7 @@ fn test_gzip_compress_binary_data() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "binary.dat", TEST_DATA_BINARY);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -190,7 +190,7 @@ fn test_gzip_compress_binary_data() {
 
     // Verify decompression works
     std::fs::remove_file(&test_file).unwrap();
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .assert()
@@ -211,7 +211,7 @@ fn test_gzip_verify_compression_reduces_size() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", compressible_content.as_bytes());
     let original_size = file_size(&test_file);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -233,7 +233,7 @@ fn test_gzip_compress_preserves_original() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
     let original_content = read_file(&test_file);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)

--- a/tests/test_options.rs
+++ b/tests/test_options.rs
@@ -11,7 +11,7 @@ fn test_timestamp_none() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-t")
@@ -33,7 +33,7 @@ fn test_timestamp_date() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-t")
@@ -61,7 +61,7 @@ fn test_timestamp_datetime() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-t")
@@ -88,7 +88,7 @@ fn test_timestamp_nanoseconds() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-t")
@@ -116,7 +116,7 @@ fn test_timestamp_default_is_none() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Without -t flag, default should be 0 (no timestamp)
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg(&test_file)
@@ -143,7 +143,7 @@ fn test_move_to_directory() {
 
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -181,7 +181,7 @@ fn test_move_to_directory_multiple_files() {
         ],
     );
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -203,7 +203,7 @@ fn test_move_to_with_timestamp() {
 
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -248,7 +248,7 @@ fn test_collect_with_parent_directory() {
 
     let archive_name = temp_dir.path().join("archive.tar.gz");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-a")
@@ -274,7 +274,7 @@ fn test_collect_flat_without_parent_directory() {
 
     let archive_name = temp_dir.path().join("archive.tar.gz");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-A")
@@ -300,7 +300,7 @@ fn test_collect_preserves_originals() {
 
     let archive_name = temp_dir.path().join("archive.tar.gz");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-a")
@@ -328,7 +328,7 @@ fn test_collect_with_bzip2() {
 
     let archive_name = temp_dir.path().join("archive.tar.bz2");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tbz2")
         .arg("-a")
@@ -354,7 +354,7 @@ fn test_collect_with_xz() {
 
     let archive_name = temp_dir.path().join("archive.tar.xz");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("txz")
         .arg("-a")
@@ -380,7 +380,7 @@ fn test_collect_with_compression_level() {
 
     let archive_name = temp_dir.path().join("archive.tar.gz");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-a")
@@ -412,7 +412,7 @@ fn test_collect_decompress() {
     let archive_name = temp_dir.path().join("archive.tar.gz");
 
     // Create archive
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-a")
@@ -427,7 +427,11 @@ fn test_collect_decompress() {
     }
 
     // Decompress archive
-    jc_command().arg("-d").arg(&archive_name).assert().success();
+    jcz_command()
+        .arg("-d")
+        .arg(&archive_name)
+        .assert()
+        .success();
 
     // Files should be restored
     assert!(
@@ -451,7 +455,7 @@ fn test_combined_move_to_and_timestamp() {
 
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("gzip")
         .arg("-C")
@@ -490,7 +494,7 @@ fn test_combined_collect_move_to_and_level() {
 
     let archive_name = output_dir.join("archive.tar.gz");
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tgz")
         .arg("-a")

--- a/tests/test_tar.rs
+++ b/tests/test_tar.rs
@@ -9,7 +9,7 @@ fn test_tar_archive_single_file() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tar")
         .arg(&test_file)
@@ -32,7 +32,7 @@ fn test_tar_archive_multiple_files() {
         ],
     );
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tar")
         .args(&files)
@@ -52,7 +52,7 @@ fn test_tar_extract_single_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // Create archive
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tar")
         .arg(&test_file)
@@ -66,7 +66,11 @@ fn test_tar_extract_single_file() {
     std::fs::remove_file(&test_file).unwrap();
 
     // Extract
-    jc_command().arg("-d").arg(&archive_file).assert().success();
+    jcz_command()
+        .arg("-d")
+        .arg(&archive_file)
+        .assert()
+        .success();
 
     let extracted_file = temp_dir.path().join("test.txt");
     assert!(file_exists(&extracted_file), "Extracted file should exist");
@@ -85,7 +89,7 @@ fn test_tar_extract_multiple_files() {
     );
 
     // Create archives
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tar")
         .args(&files)
@@ -100,7 +104,7 @@ fn test_tar_extract_multiple_files() {
     std::fs::remove_file(&files[1]).unwrap();
 
     // Extract both
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&tar1)
         .arg(&tar2)
@@ -119,7 +123,7 @@ fn test_tar_archive_preserves_original() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
     let original_content = read_file(&test_file);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tar")
         .arg(&test_file)
@@ -139,7 +143,7 @@ fn test_tar_archive_binary_data() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "binary.dat", TEST_DATA_BINARY);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tar")
         .arg(&test_file)
@@ -151,7 +155,11 @@ fn test_tar_archive_binary_data() {
 
     // Verify extraction works
     std::fs::remove_file(&test_file).unwrap();
-    jc_command().arg("-d").arg(&archive_file).assert().success();
+    jcz_command()
+        .arg("-d")
+        .arg(&archive_file)
+        .assert()
+        .success();
 
     assert_eq!(
         read_file(&temp_dir.path().join("binary.dat")),
@@ -165,7 +173,7 @@ fn test_tar_verify_archive_contains_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
     let file_name = test_file.file_name().unwrap().to_str().unwrap();
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tar")
         .arg(&test_file)
@@ -195,7 +203,7 @@ fn test_tar_with_compression_level_ignored() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // TAR doesn't use compression level, but command should not fail
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("tar")
         .arg("-l")

--- a/tests/test_xz.rs
+++ b/tests/test_xz.rs
@@ -8,7 +8,7 @@ fn test_xz_compress_single_file() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg(&test_file)
@@ -34,7 +34,7 @@ fn test_xz_compress_multiple_files() {
         ],
     );
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .args(&files)
@@ -52,7 +52,7 @@ fn test_xz_compress_with_level_1() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg("-l")
@@ -70,7 +70,7 @@ fn test_xz_compress_with_level_9() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg("-l")
@@ -88,7 +88,7 @@ fn test_xz_compress_with_default_level() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_MEDIUM);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg(&test_file)
@@ -105,7 +105,7 @@ fn test_xz_decompress_single_file() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
 
     // First compress
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg(&test_file)
@@ -119,7 +119,7 @@ fn test_xz_decompress_single_file() {
     std::fs::remove_file(&test_file).unwrap();
 
     // Now decompress
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .assert()
@@ -145,7 +145,7 @@ fn test_xz_decompress_multiple_files() {
     );
 
     // Compress both files
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .args(&files)
@@ -160,7 +160,7 @@ fn test_xz_decompress_multiple_files() {
     std::fs::remove_file(&files[1]).unwrap();
 
     // Decompress both
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&xz1)
         .arg(&xz2)
@@ -178,7 +178,7 @@ fn test_xz_compress_binary_data() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = create_test_file(temp_dir.path(), "binary.dat", TEST_DATA_BINARY);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg(&test_file)
@@ -190,7 +190,7 @@ fn test_xz_compress_binary_data() {
 
     // Verify decompression works
     std::fs::remove_file(&test_file).unwrap();
-    jc_command()
+    jcz_command()
         .arg("-d")
         .arg(&compressed_file)
         .assert()
@@ -211,7 +211,7 @@ fn test_xz_verify_compression_reduces_size() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", compressible_content.as_bytes());
     let original_size = file_size(&test_file);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg(&test_file)
@@ -233,7 +233,7 @@ fn test_xz_compress_preserves_original() {
     let test_file = create_test_file(temp_dir.path(), "test.txt", TEST_DATA_SMALL);
     let original_content = read_file(&test_file);
 
-    jc_command()
+    jcz_command()
         .arg("-c")
         .arg("xz")
         .arg(&test_file)


### PR DESCRIPTION
## Summary

Rename the project from `jc` to `jcz` (Just Compress Zip) to avoid naming conflicts with the existing `jc` command (JSON Convert) available in standard Linux repositories.

## Changes

### Package and Binary
- Updated package name from `jc` to `jcz` in Cargo.toml
- Updated binary name from `jc` to `jcz`
- Updated authors from "JC Contributors" to "JCZ Contributors"
- Updated description to "Just Compress Zip"

### Documentation
- Renamed `docs/jc_srs.md` → `docs/jcz_srs.md`
- Renamed `docs/jc_sdd.md` → `docs/jcz_sdd.md`
- Updated all documentation content with new name
- Updated README with new command examples
- Updated tests/README.md

### CLI and Source Code
- Updated CLI command name and description in `src/cli/args.rs`
- Updated temp directory prefix: `jcpkg_` → `jczpkg_`
- Updated write test file: `.jc_write_test` → `.jcz_write_test`
- Updated all code comments referencing old name

### Tests
- Renamed helper function: `jc_command()` → `jcz_command()`
- Updated all test files to use new function name
- All 99 tests passing

### Workflows
- Updated release workflow to use `jcz` naming
- Updated source tarball prefix: `jc-VERSION` → `jcz-VERSION`
- Updated Debian package naming: `jc_VERSION_amd64.deb` → `jcz_VERSION_amd64.deb`
- Updated package metadata and binary path

## Testing

- ✅ All 99 tests passing (87 passed + 12 ignored)
- ✅ Release build successful
- ✅ Binary verified working: `jcz 0.1.3`

## Rationale

The name `jc` conflicts with the `jc` (JSON Convert) command already available in standard repositories. The new name `jcz` (Just Compress Zip) avoids this conflict while maintaining the spirit of the original name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)